### PR TITLE
Events, grades and backup

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -15,12 +15,18 @@ this module template code.
   all the instances of the string "newmodule" to your module name
   (eg "widget"). If you are using Linux, you can use the following command
   $ find . -type f -exec sed -i 's/newmodule/widget/g' {} \;
-  
+
   On a mac, use:
   $ find . -type f -exec sed -i '' 's/newmodule/widget/g' {} \;
 
 * Rename the file lang/en/newmodule.php to lang/en/widget.php
   where "widget" is the name of your module
+
+* Rename all files in backup/moodle2/ folder by replacing "newmodule" with
+  the name of your module
+
+  On Linux you can perform this and previous steps by calling:
+  $ find . -depth -name '*newmodule*' -execdir bash -c 'mv -i "$1" "${1//newmodule/widget}"' bash {} \;
 
 * Place the widget folder into the /mod folder of the moodle
   directory.

--- a/backup/moodle2/backup_newmodule_activity_task.class.php
+++ b/backup/moodle2/backup_newmodule_activity_task.class.php
@@ -1,0 +1,74 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Defines backup_newmodule_activity_task class
+ *
+ * @package   mod_newmodule
+ * @category  backup
+ * @copyright 2011 Your Name <your@email.adress>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+require_once($CFG->dirroot . '/mod/newmodule/backup/moodle2/backup_newmodule_stepslib.php');
+
+/**
+ * Provides the steps to perform one complete backup of the newmodule instance
+ *
+ * @package   mod_newmodule
+ * @category  backup
+ * @copyright 2011 Your Name <your@email.adress>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class backup_newmodule_activity_task extends backup_activity_task {
+
+    /**
+     * No specific settings for this activity
+     */
+    protected function define_my_settings() {
+    }
+
+    /**
+     * Defines a backup step to store the instance data in the newmodule.xml file
+     */
+    protected function define_my_steps() {
+        $this->add_step(new backup_newmodule_activity_structure_step('newmodule_structure', 'newmodule.xml'));
+    }
+
+    /**
+     * Encodes URLs to the index.php and view.php scripts
+     *
+     * @param string $content some HTML text that eventually contains URLs to the activity instance scripts
+     * @return string the content with the URLs encoded
+     */
+    static public function encode_content_links($content) {
+        global $CFG;
+
+        $base = preg_quote($CFG->wwwroot,"/");
+
+        // Link to the list of newmodulees
+        $search="/(".$base."\/mod\/newmodule\/index.php\?id\=)([0-9]+)/";
+        $content= preg_replace($search, '$@NEWMODULEINDEX*$2@$', $content);
+
+        // Link to newmodule view by moduleid
+        $search="/(".$base."\/mod\/newmodule\/view.php\?id\=)([0-9]+)/";
+        $content= preg_replace($search, '$@NEWMODULEVIEWBYID*$2@$', $content);
+
+        return $content;
+    }
+}

--- a/backup/moodle2/backup_newmodule_stepslib.php
+++ b/backup/moodle2/backup_newmodule_stepslib.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Define all the backup steps that will be used by the backup_newmodule_activity_task
+ *
+ * @package   mod_newmodule
+ * @category  backup
+ * @copyright 2011 Your Name <your@email.adress>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * Define the complete newmodule structure for backup, with file and id annotations
+ *
+ * @package   mod_newmodule
+ * @category  backup
+ * @copyright 2011 Your Name <your@email.adress>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class backup_newmodule_activity_structure_step extends backup_activity_structure_step {
+
+    protected function define_structure() {
+
+        // To know if we are including userinfo
+        $userinfo = $this->get_setting_value('userinfo');
+
+        // Define each element separated
+        $newmodule = new backup_nested_element('newmodule', array('id'), array(
+            'name', 'intro', 'introformat', 'grade'));
+
+        // Build the tree
+
+        // Define sources
+        $newmodule->set_source_table('newmodule', array('id' => backup::VAR_ACTIVITYID));
+
+        // Define id annotations
+
+        // Define file annotations
+        $newmodule->annotate_files('mod_newmodule', 'intro', null); // This file areas haven't itemid
+
+        // Return the root element (newmodule), wrapped into standard activity structure
+        return $this->prepare_activity_structure($newmodule);
+    }
+}

--- a/backup/moodle2/restore_newmodule_activity_task.class.php
+++ b/backup/moodle2/restore_newmodule_activity_task.class.php
@@ -1,0 +1,113 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package   mod_newmodule
+ * @category  backup
+ * @copyright 2011 Your Name <your@email.adress>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/mod/newmodule/backup/moodle2/restore_newmodule_stepslib.php'); // Because it exists (must)
+
+/**
+ * newmodule restore task that provides all the settings and steps to perform one
+ * complete restore of the activity
+ *
+ * @package   mod_newmodule
+ * @category  backup
+ * @copyright 2011 Your Name <your@email.adress>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class restore_newmodule_activity_task extends restore_activity_task {
+
+    /**
+     * Define (add) particular settings this activity can have
+     */
+    protected function define_my_settings() {
+        // No particular settings for this activity
+    }
+
+    /**
+     * Define (add) particular steps this activity can have
+     */
+    protected function define_my_steps() {
+        // label only has one structure step
+        $this->add_step(new restore_newmodule_activity_structure_step('newmodule_structure', 'newmodule.xml'));
+    }
+
+    /**
+     * Define the contents in the activity that must be
+     * processed by the link decoder
+     */
+    static public function define_decode_contents() {
+        $contents = array();
+
+        $contents[] = new restore_decode_content('newmodule', array('intro'), 'newmodule');
+
+        return $contents;
+    }
+
+    /**
+     * Define the decoding rules for links belonging
+     * to the activity to be executed by the link decoder
+     */
+    static public function define_decode_rules() {
+        $rules = array();
+
+        $rules[] = new restore_decode_rule('NEWMODULEVIEWBYID', '/mod/newmodule/view.php?id=$1', 'course_module');
+        $rules[] = new restore_decode_rule('NEWMODULEINDEX', '/mod/newmodule/index.php?id=$1', 'course');
+
+        return $rules;
+
+    }
+
+    /**
+     * Define the restore log rules that will be applied
+     * by the {@link restore_logs_processor} when restoring
+     * newmodule logs. It must return one array
+     * of {@link restore_log_rule} objects
+     */
+    static public function define_restore_log_rules() {
+        $rules = array();
+
+        $rules[] = new restore_log_rule('newmodule', 'add', 'view.php?id={course_module}', '{newmodule}');
+        $rules[] = new restore_log_rule('newmodule', 'update', 'view.php?id={course_module}', '{newmodule}');
+        $rules[] = new restore_log_rule('newmodule', 'view', 'view.php?id={course_module}', '{newmodule}');
+
+        return $rules;
+    }
+
+    /**
+     * Define the restore log rules that will be applied
+     * by the {@link restore_logs_processor} when restoring
+     * course logs. It must return one array
+     * of {@link restore_log_rule} objects
+     *
+     * Note this rules are applied when restoring course logs
+     * by the restore final task, but are defined here at
+     * activity level. All them are rules not linked to any module instance (cmid = 0)
+     */
+    static public function define_restore_log_rules_for_course() {
+        $rules = array();
+
+        $rules[] = new restore_log_rule('newmodule', 'view all', 'index.php?id={course}', null);
+
+        return $rules;
+    }
+}

--- a/backup/moodle2/restore_newmodule_stepslib.php
+++ b/backup/moodle2/restore_newmodule_stepslib.php
@@ -1,0 +1,74 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Define all the restore steps that will be used by the restore_newmodule_activity_task
+ *
+ * @package   mod_newmodule
+ * @category  backup
+ * @copyright 2011 Your Name <your@email.adress>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Structure step to restore one newmodule activity
+ *
+ * @package   mod_newmodule
+ * @category  backup
+ * @copyright 2011 Your Name <your@email.adress>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class restore_newmodule_activity_structure_step extends restore_activity_structure_step {
+
+    protected function define_structure() {
+
+        $paths = array();
+        $paths[] = new restore_path_element('newmodule', '/activity/newmodule');
+
+        // Return the paths wrapped into standard activity structure
+        return $this->prepare_activity_structure($paths);
+    }
+
+    protected function process_newmodule($data) {
+        global $DB;
+
+        $data = (object)$data;
+        $oldid = $data->id;
+        $data->course = $this->get_courseid();
+
+        if (empty($data->timecreated)) {
+            $data->timecreated = time();
+        }
+
+        if (empty($data->timemodified)) {
+            $data->timemodified = time();
+        }
+
+        if ($data->grade < 0) { // Scale found, get mapping.
+            $data->grade = -($this->get_mappingid('scale', abs($data->grade)));
+        }
+
+        // insert the newmodule record
+        $newitemid = $DB->insert_record('newmodule', $data);
+        // immediately after inserting "activity" record, call this
+        $this->apply_activity_instance($newitemid);
+    }
+
+    protected function after_execute() {
+        // Add newmodule related files, no need to match by itemname (just internally handled context)
+        $this->add_related_files('mod_newmodule', 'intro', null);
+    }
+}

--- a/classes/event/course_module_instance_list_viewed.php
+++ b/classes/event/course_module_instance_list_viewed.php
@@ -1,0 +1,37 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The mod_newmodule instance list viewed event.
+ *
+ * @package    mod_newmodule
+ * @copyright  2011 Your Name <your@email.adress>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_newmodule\event;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * The mod_newmodule instance list viewed event class.
+ *
+ * @package    mod_newmodule
+ * @copyright  2011 Your Name <your@email.adress>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class course_module_instance_list_viewed extends \core\event\course_module_instance_list_viewed {
+}

--- a/classes/event/course_module_viewed.php
+++ b/classes/event/course_module_viewed.php
@@ -18,13 +18,20 @@
  * Defines the view event.
  *
  * @package    mod_newmodule
- * @copyright  2014 Daniel Neis Araujo
+ * @copyright  2011 Your Name <your@email.adress>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace mod_newmodule\event;
 defined('MOODLE_INTERNAL') || die();
 
+/**
+ * The mod_newmodule instance list viewed event class.
+ *
+ * @package    mod_newmodule
+ * @copyright  2011 Your Name <your@email.adress>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 class course_module_viewed extends \core\event\course_module_viewed {
     protected function init() {
         $this->data['objecttable'] = 'newmodule';

--- a/db/install.xml
+++ b/db/install.xml
@@ -6,13 +6,14 @@
   <TABLES>
     <TABLE NAME="newmodule" COMMENT="Default comment for newmodule, please edit me">
       <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true" NEXT="course"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="false" COMMENT="Course newmodule activity belongs to" PREVIOUS="id" NEXT="name"/>
-        <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="name field for moodle instances" PREVIOUS="course" NEXT="intro"/>
-        <FIELD NAME="intro" TYPE="text" LENGTH="big" NOTNULL="false" SEQUENCE="false" COMMENT="General introduction of the newmodule activity" PREVIOUS="name" NEXT="introformat"/>
-        <FIELD NAME="introformat" TYPE="int" LENGTH="4" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" COMMENT="Format of the intro field (MOODLE, HTML, MARKDOWN...)" PREVIOUS="intro" NEXT="timecreated"/>
-        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="false" PREVIOUS="introformat" NEXT="timemodified"/>
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="timecreated"/>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true"/>
+        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="false" COMMENT="Course newmodule activity belongs to"/>
+        <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="name field for moodle instances"/>
+        <FIELD NAME="intro" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="General introduction of the newmodule activity"/>
+        <FIELD NAME="introformat" TYPE="int" LENGTH="4" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" COMMENT="Format of the intro field (MOODLE, HTML, MARKDOWN...)"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="grade" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="100" SEQUENCE="false" COMMENT="The maximum grade. Can be negative to indicate the use of a scale."/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/grade.php
+++ b/grade.php
@@ -23,7 +23,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(__DIR__ . "../../config.php");
+require_once(__DIR__ . "../../../config.php");
 
 $id = required_param('id', PARAM_INT);// Course module ID.
 // Item number may be != 0 for activities that allow more than one grade per user.

--- a/index.php
+++ b/index.php
@@ -36,52 +36,64 @@ $course = $DB->get_record('course', array('id' => $id), '*', MUST_EXIST);
 
 require_course_login($course);
 
-add_to_log($course->id, 'newmodule', 'view all', 'index.php?id='.$course->id, '');
+$params = array(
+    'context' => context_course::instance($course->id)
+);
+$event = \mod_newmodule\event\course_module_instance_list_viewed::create($params);
+$event->add_record_snapshot('course', $course);
+$event->trigger();
 
-$coursecontext = context_course::instance($course->id);
-
+$strname = get_string('modulenameplural', 'mod_newmodule');
 $PAGE->set_url('/mod/newmodule/index.php', array('id' => $id));
-$PAGE->set_title(format_string($course->fullname));
-$PAGE->set_heading(format_string($course->fullname));
-$PAGE->set_context($coursecontext);
+$PAGE->navbar->add($strname);
+$PAGE->set_title("$course->shortname: $strname");
+$PAGE->set_heading($course->fullname);
+$PAGE->set_pagelayout('incourse');
 
 echo $OUTPUT->header();
+echo $OUTPUT->heading($strname);
 
 if (! $newmodules = get_all_instances_in_course('newmodule', $course)) {
     notice(get_string('nonewmodules', 'newmodule'), new moodle_url('/course/view.php', array('id' => $course->id)));
 }
 
+$usesections = course_format_uses_sections($course->format);
+
 $table = new html_table();
-if ($course->format == 'weeks') {
-    $table->head  = array(get_string('week'), get_string('name'));
-    $table->align = array('center', 'left');
-} else if ($course->format == 'topics') {
-    $table->head  = array(get_string('topic'), get_string('name'));
-    $table->align = array('center', 'left', 'left', 'left');
+$table->attributes['class'] = 'generaltable mod_index';
+
+if ($usesections) {
+    $strsectionname = get_string('sectionname', 'format_'.$course->format);
+    $table->head  = array ($strsectionname, $strname);
+    $table->align = array ('center', 'left');
 } else {
-    $table->head  = array(get_string('name'));
-    $table->align = array('left', 'left', 'left');
+    $table->head  = array ($strname);
+    $table->align = array ('left');
 }
 
-foreach ($newmodules as $newmodule) {
-    if (!$newmodule->visible) {
-        $link = html_writer::link(
-            new moodle_url('/mod/newmodule.php', array('id' => $newmodule->coursemodule)),
-            format_string($newmodule->name, true),
-            array('class' => 'dimmed'));
-    } else {
-        $link = html_writer::link(
-            new moodle_url('/mod/newmodule.php', array('id' => $newmodule->coursemodule)),
-            format_string($newmodule->name, true));
+$modinfo = get_fast_modinfo($course);
+$currentsection = '';
+foreach ($modinfo->instances['newmodule'] as $cm) {
+    $row = array();
+    if ($usesections) {
+        if ($cm->sectionnum !== $currentsection) {
+            if ($cm->sectionnum) {
+                $row[] = get_section_name($course, $cm->sectionnum);
+            }
+            if ($currentsection !== '') {
+                $table->data[] = 'hr';
+            }
+            $currentsection = $cm->sectionnum;
+        }
     }
 
-    if ($course->format == 'weeks' or $course->format == 'topics') {
-        $table->data[] = array($newmodule->section, $link);
-    } else {
-        $table->data[] = array($link);
-    }
+    $class = $cm->visible ? null : array('class' => 'dimmed'); // hidden modules are dimmed
+
+    $row[] = html_writer::link(new moodle_url('view.php', array('id' => $cm->id)),
+                $cm->get_formatted_name(), $class);
+    $table->data[] = $row;
 }
 
-echo $OUTPUT->heading(get_string('modulenameplural', 'newmodule'), 2);
 echo html_writer::table($table);
+
 echo $OUTPUT->footer();

--- a/lib.php
+++ b/lib.php
@@ -54,6 +54,8 @@ function newmodule_supports($feature) {
             return true;
         case FEATURE_GRADE_HAS_GRADE:
             return true;
+        case FEATURE_BACKUP_MOODLE2:
+            return true;
         default:
             return null;
     }

--- a/lib.php
+++ b/lib.php
@@ -381,8 +381,9 @@ function newmodule_pluginfile($course, $cm, $context, $filearea, array $args, $f
  * @param stdClass $module
  * @param cm_info $cm
  */
-function newmodule_extend_navigation(navigation_node $navref, stdclass $course, stdclass $module, cm_info $cm) {
-}
+//function newmodule_extend_navigation(navigation_node $navref, stdclass $course, stdclass $module, cm_info $cm) {
+//    Uncomment to extend navigation for the activity.
+//}
 
 /**
  * Extends the settings navigation with the newmodule settings

--- a/mod_form.php
+++ b/mod_form.php
@@ -65,6 +65,9 @@ class mod_newmodule_mod_form extends moodleform_mod {
         $mform->addElement('header', 'newmodulefieldset', get_string('newmodulefieldset', 'newmodule'));
         $mform->addElement('static', 'label2', 'newmodulesetting2', 'Your newmodule fields go here. Replace me!');
 
+        // Add standard grading elements.
+        $this->standard_grading_coursemodule_elements();
+
         // Add standard elements, common to all modules.
         $this->standard_coursemodule_elements();
 

--- a/version.php
+++ b/version.php
@@ -30,6 +30,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 0;               // The current module version (Date: YYYYMMDDXX).
                                       // If version == 0 then module will not be installed.
-$plugin->requires  = 2010031900;      // Requires this Moodle version.
+$plugin->requires  = 2014051200;      // Requires this Moodle version (Moodle 2.7).
 $plugin->cron      = 0;               // Period for cron to check this module (secs).
 $plugin->component = 'mod_newmodule'; // To check on upgrade, that module sits in correct place.

--- a/view.php
+++ b/view.php
@@ -46,15 +46,13 @@ if ($id) {
 }
 
 require_login($course, true, $cm);
-$context = context_module::instance($cm->id);
 
 $event = \mod_newmodule\event\course_module_viewed::create(array(
     'objectid' => $PAGE->cm->instance,
     'context' => $PAGE->context,
 ));
 $event->add_record_snapshot('course', $PAGE->course);
-// In the next line you can use $PAGE->activityrecord if you have set it, or skip this line if you don't have a record.
-$event->add_record_snapshot($PAGE->cm->modname, $activityrecord);
+$event->add_record_snapshot($PAGE->cm->modname, $newmodule);
 $event->trigger();
 
 // Print the page header.
@@ -62,7 +60,6 @@ $event->trigger();
 $PAGE->set_url('/mod/newmodule/view.php', array('id' => $cm->id));
 $PAGE->set_title(format_string($newmodule->name));
 $PAGE->set_heading(format_string($course->fullname));
-$PAGE->set_context($context);
 
 /*
  * Other things you may want to set - remove if not needed.


### PR DESCRIPTION
1. Corrected error in event in view.php, bumped required Moodle version to 2.7 (otherwise this new event would not work)
2. index.php was completely broken - corrected, added proper event for it
3. (small one) commented callback to extend navigation
4. completed support for grading that was present partially (and therefore causing the errors when requesting non-existing column)
5. added backup classes that are needed for backup or duplicating of activity
