### PR TITLE
Add very basic behat test

### DIFF
--- a/tests/behat/installed.feature
+++ b/tests/behat/installed.feature
@@ -1,0 +1,12 @@
+@mod @mod_newmodule
+Feature: Installation succeeds
+  In order to use this plugin
+  As a user
+  I need the installation to work
+
+  Scenario: Check the Plugins overview for the name of this plugin
+    Given I log in as "admin"
+    And I navigate to "Plugins overview" node in "Site administration > Plugins"
+    Then the following should exist in the "plugins-control-panel" table:
+        |Plugin name|
+        |mod_newmodule|


### PR DESCRIPTION
It's a good idea to encourage new modules to have proper tests, having a very simple behat test that they can run might encourage people to write more.

I'm trying to think of a similarly basic phpunit test that would at least confirm that they've e.g. actually changed "newmodule" to "widget" in various places.